### PR TITLE
Stop listening to keep-alive messages

### DIFF
--- a/vor-android/mobile/src/main/java/com/futurice/hereandnow/Constants.java
+++ b/vor-android/mobile/src/main/java/com/futurice/hereandnow/Constants.java
@@ -20,6 +20,7 @@ public class Constants {
     public static final String TEMPERATURE_KEY = "temperature";
     public static final String TYPE_KEY = "type";
     public static final String LOCATION_KEY = "location";
+    public static final String KEEP_ALIVE_KEY = "keep-alive";
     public static final String MESSAGE_KEY = "message";
     public static final String INIT_BEACONS_KEY = "beacons";
     public static final String INIT_MESSAGES_KEY = "messages";

--- a/vor-android/mobile/src/main/java/com/futurice/hereandnow/HereAndNowApplication.java
+++ b/vor-android/mobile/src/main/java/com/futurice/hereandnow/HereAndNowApplication.java
@@ -76,14 +76,17 @@ public class HereAndNowApplication extends Application {
                 .on(LOCATION_KEY, args -> Log.d(TAG, "LOCATION RECEIVED"))
                 .on(MESSAGE_KEY, args -> {
                     try {
-                        //
                         JSONObject jsonObject = (JSONObject)args[0];
-                        if (jsonObject.getString(TYPE_KEY).equals(LOCATION_KEY)) {
-                            beaconLocationManager.onLocation(jsonObject);
-                        } else if (jsonObject.getString(TYPE_KEY).equals(KEEP_ALIVE_KEY)) {
-                            // TODO Deal with the keep alive message
-                        } else {
-                            SharedPreferencesManager.saveToSharedPreferences((JSONObject) args[0], this);
+                        switch (jsonObject.getString(TYPE_KEY)) {
+                            case LOCATION_KEY:
+                                beaconLocationManager.onLocation(jsonObject);
+                                break;
+                            case KEEP_ALIVE_KEY:
+                                // TODO Deal with the keep alive message
+                                break;
+                            default:
+                                SharedPreferencesManager.saveToSharedPreferences(jsonObject, this);
+                                break;
                         }
                     } catch (JSONException e) {
                         e.printStackTrace();

--- a/vor-android/mobile/src/main/java/com/futurice/hereandnow/HereAndNowApplication.java
+++ b/vor-android/mobile/src/main/java/com/futurice/hereandnow/HereAndNowApplication.java
@@ -80,6 +80,8 @@ public class HereAndNowApplication extends Application {
                         JSONObject jsonObject = (JSONObject)args[0];
                         if (jsonObject.getString(TYPE_KEY).equals(LOCATION_KEY)) {
                             beaconLocationManager.onLocation(jsonObject);
+                        } else if (jsonObject.getString(TYPE_KEY).equals(KEEP_ALIVE_KEY)) {
+                            // TODO Deal with the keep alive message
                         } else {
                             SharedPreferencesManager.saveToSharedPreferences((JSONObject) args[0], this);
                         }


### PR DESCRIPTION
Kenta's beacons are sending a `keep-alive` type of message, like this:

`{"type":"keep-alive","id":"toilet8am"}`

In the SharedPreferences we are saving/updating based on the ID, so when the client gets that it assumes it's an update, but it's not. So we can just ignore it for now.

The keep-alive message comes every 5 minutes or so, not sure what to do with it yet. One suggestion would be to just keep a timer and if we don't get any message for like 5+ minutes than just say "Service Unavailable" or something. This raises a problem that we will be saving to SharedPreferences much more often, literally every 5 minutes to everything we have. Not sure if this is ideal. What are your thoughts?
