### PR TITLE
Fix a broken link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please have a look at the subdirectories corresponding to the different parts of
 
 [JSON](/doc/json-schema.md) describing the different messages sent and received by phones and Arduinos, echoed to clients on the local WLAN by the Node.js server to create a local bus with end-to-end push using websockets
 
-[Design](/vor-design/README.md) visual design assets
+[Design](/design/README.md) visual design assets
 
 [Android](/vor-android/README.md) for the Android client to track your location indoors and interact with the map and service cards. A custom build for fixed table display helps office visitor interact with the service.
 


### PR DESCRIPTION
I assume Design is supposed to link to /design/README.md instead of /vor-design/README.md, which doesn't exist.
